### PR TITLE
Make dataprovider static to get rid of a PHPUnit 10 deprecation

### DIFF
--- a/tests/MockDelegateFunctionBuilderTest.php
+++ b/tests/MockDelegateFunctionBuilderTest.php
@@ -89,7 +89,7 @@ class MockDelegateFunctionBuilderTest extends TestCase
      *
      * @return array Test cases.
      */
-    public function provideTestBackupStaticAttributes()
+    public static function provideTestBackupStaticAttributes()
     {
         return [
             [],


### PR DESCRIPTION
there's another one left, but it uses `$this->getMockForAbstractClass()` and I had no good idea on how to change that / it might not be worth..