### PR TITLE
Avoid PHP type deprecation on function call

### DIFF
--- a/classes/MockDelegateFunctionBuilder.php
+++ b/classes/MockDelegateFunctionBuilder.php
@@ -49,7 +49,7 @@ class MockDelegateFunctionBuilder
     public function build($functionName = null)
     {
         $parameterBuilder = new ParameterBuilder();
-        $parameterBuilder->build($functionName);
+        $parameterBuilder->build($functionName === null ? '' : $functionName);
         $signatureParameters = $parameterBuilder->getSignatureParameters();
 
         /**


### PR DESCRIPTION
get's rid of
```
1) phpmock\integration\MockDelegateFunctionBuilderTest::testBuild
function_exists(): Passing null to parameter #1 ($function) of type string is deprecated

/Users/herndlm/Development/source/git-forks/php-mock-integration/tests/MockDelegateFunctionBuilderTest.php:23

2) phpmock\integration\MockDelegateFunctionTest::testDelegateReturnsMockResult
function_exists(): Passing null to parameter #1 ($function) of type string is deprecated

/Users/herndlm/Development/source/git-forks/php-mock-integration/tests/MockDelegateFunctionTest.php:38

3) phpmock\integration\MockDelegateFunctionTest::testDelegateForwardsArguments
function_exists(): Passing null to parameter #1 ($function) of type string is deprecated

/Users/herndlm/Development/source/git-forks/php-mock-integration/tests/MockDelegateFunctionTest.php:56
```

which comes from calling https://github.com/php-mock/php-mock/blob/2.4.0/classes/generator/ParameterBuilder.php#L32 with `null`. According to that PHPDoc this is invalid already anyways and static analysis would catch that.