### PR TITLE
Maintenance: support phpunit v12 & php-text-template v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
     "require": {
         "php": ">=5.6",
         "php-mock/php-mock": "^2.5",
-        "phpunit/php-text-template": "^1 || ^2 || ^3 || ^4"
+        "phpunit/php-text-template": "^1 || ^2 || ^3 || ^4 || ^5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.27 || ^6 || ^7 || ^8 || ^9 || ^10 || ^11"
+        "phpunit/phpunit": "^5.7.27 || ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12"
     },
     "archive": {
         "exclude": ["/tests"]

--- a/tests/MockDelegateFunctionBuilderTest.php
+++ b/tests/MockDelegateFunctionBuilderTest.php
@@ -71,6 +71,9 @@ class MockDelegateFunctionBuilderTest extends TestCase
      *
      * @doesNotPerformAssertions
      */
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideTestBackupStaticAttributes')]
+    #[\PHPUnit\Framework\Attributes\BackupStaticProperties(true)]
     public function testBackupStaticAttributes()
     {
         $builder = new MockDelegateFunctionBuilder();
@@ -97,12 +100,14 @@ class MockDelegateFunctionBuilderTest extends TestCase
      *
      * @doesNotPerformAssertions
      */
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
     public function testDeserializationInNewProcess()
     {
         $builder = new MockDelegateFunctionBuilder();
         $builder->build("min");
 
-        $data = serialize($this->getMockForAbstractClass($builder->getFullyQualifiedClassName()));
+        $data = serialize($this->getMockBuilder($builder->getFullyQualifiedClassName())->getMock());
         
         unserialize($data);
     }

--- a/tests/MockDelegateFunctionTest.php
+++ b/tests/MockDelegateFunctionTest.php
@@ -35,10 +35,13 @@ class MockDelegateFunctionTest extends TestCase
      *
      * @test
      */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function testDelegateReturnsMockResult()
     {
         $expected = 3;
-        $mock     = $this->getMockForAbstractClass($this->className);
+        $mock     = $this->getMockBuilder($this->className)
+            ->onlyMethods([MockDelegateFunctionBuilder::METHOD])
+            ->getMock();
         
         $mock->expects($this->once())
              ->method(MockDelegateFunctionBuilder::METHOD)
@@ -53,14 +56,17 @@ class MockDelegateFunctionTest extends TestCase
      *
      * @test
      */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function testDelegateForwardsArguments()
     {
-        $mock = $this->getMockForAbstractClass($this->className);
-        
+        $mock     = $this->getMockBuilder($this->className)
+            ->onlyMethods([MockDelegateFunctionBuilder::METHOD])
+            ->getMock();
+
         $mock->expects($this->once())
              ->method(MockDelegateFunctionBuilder::METHOD)
              ->with(1, 2);
-        
+
         call_user_func($mock->getCallable(), 1, 2);
     }
 }

--- a/tests/MockDelegateFunctionTest.php
+++ b/tests/MockDelegateFunctionTest.php
@@ -38,11 +38,18 @@ class MockDelegateFunctionTest extends TestCase
     #[\PHPUnit\Framework\Attributes\Test]
     public function testDelegateReturnsMockResult()
     {
-        $expected = 3;
-        $mock     = $this->getMockBuilder($this->className)
-            ->onlyMethods([MockDelegateFunctionBuilder::METHOD])
-            ->getMock();
-        
+        $expected    = 3;
+        $mockBuilder = $this->getMockBuilder($this->className);
+
+        // `setMethods` is gone from phpunit 10, alternative is `onlyMethods`
+        if (method_exists($mockBuilder, 'onlyMethods')) {
+            $mockBuilder->onlyMethods([MockDelegateFunctionBuilder::METHOD]);
+        } else {
+            $mockBuilder->setMethods([MockDelegateFunctionBuilder::METHOD]);
+        }
+
+        $mock = $mockBuilder->getMock();
+
         $mock->expects($this->once())
              ->method(MockDelegateFunctionBuilder::METHOD)
              ->willReturn($expected);
@@ -59,9 +66,16 @@ class MockDelegateFunctionTest extends TestCase
     #[\PHPUnit\Framework\Attributes\Test]
     public function testDelegateForwardsArguments()
     {
-        $mock     = $this->getMockBuilder($this->className)
-            ->onlyMethods([MockDelegateFunctionBuilder::METHOD])
-            ->getMock();
+        $mockBuilder = $this->getMockBuilder($this->className);
+
+        // `setMethods` is gone from phpunit 10, alternative is `onlyMethods`
+        if (method_exists($mockBuilder, 'onlyMethods')) {
+            $mockBuilder->onlyMethods([MockDelegateFunctionBuilder::METHOD]);
+        } else {
+            $mockBuilder->setMethods([MockDelegateFunctionBuilder::METHOD]);
+        }
+
+        $mock = $mockBuilder->getMock();
 
         $mock->expects($this->once())
              ->method(MockDelegateFunctionBuilder::METHOD)


### PR DESCRIPTION
- support new version `phpunit/php-text-template` (^5);
- support new version `phpunit/phpunit` (^12.0);
- add attribute for each annotation to support phpunit 12;
- use MockBuilder for building mocks instead of removed `getMockForAbstractClass` method